### PR TITLE
Fixed typo which allowed LICENSE file to be included in build.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -69,7 +69,7 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - README.md
-  - LICENCE
+  - LICENSE
 
 # -----------
 # CloudCannon


### PR DESCRIPTION
This fixes a typo which allows site users to access the project's LICENSE file.