### PR TITLE
Don't build GA script section if GA key is nil

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
 		<link rel="stylesheet" href="{{ site.baseurl }}/css/screen.css">
 		<link rel="icon" type="image/png" href="{{ site.baseurl }}/favicon.png">
 
-		{% if jekyll.environment == 'production' and site.google_analytics_key != '' %}
+		{% if jekyll.environment == 'production' and site.google_analytics_key and site.google_analytics_key != '' %}
 			<script>
 				window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
 				ga('create', '{{ site.google_analytics_key }}', 'auto');


### PR DESCRIPTION
Currently, leaving an empty `google_analytics_key` (or not having it in your `_config.yml` at all) still builds the `<script>` block for Google Analytics, because the value of `site.google_analytics_key` is `nil`, not `""`. This fixes by testing against [truthiness](https://shopify.github.io/liquid/basics/truthy-and-falsy/), so values of `nil` or `false` will also work.