### PR TITLE
Combine duplicated class attributes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,7 +30,7 @@
 		{{ content }}
 		<footer>
 			<div class="container">
-				<p class="editor-link"><a href="cloudcannon:collections/_data/footer.yml" class="btn"><strong>&#9998;</strong> Edit footer</a></p>
+				<p class="editor-link btn"><a href="cloudcannon:collections/_data/footer.yml"><strong>&#9998;</strong> Edit footer</a></p>
 				<div class="footer-columns">
 					{% for column in site.data.footer %}
 					<ul class="footer-links">


### PR DESCRIPTION
default.html had a validation error because there was an element with multiple class attributes. This PR fixes this by combining them.